### PR TITLE
GPU scaling sweep results + cloud_run_v1 to serial baseline

### DIFF
--- a/BATCHED_EVALUATOR_DESIGN.md
+++ b/BATCHED_EVALUATOR_DESIGN.md
@@ -1,10 +1,27 @@
 # Shared `BatchedEvaluator` — Design Sketch
 
-> **Status**: design. Not implemented. Companion to
-> `GPU_SCALING_PLAN.md` (PR #11) and `GPU_SCALING_RESULTS.md`. The
+> **2026-05-06 postscript — read this first.** The design below was
+> implemented in PR #12 and measured on a 4090 cloud box. **It does
+> not deliver the predicted 3-5× speedup.** Serial mode (no threads,
+> no evaluator) measured 702 games/hr; the threaded path measured
+> 470-541 across `num_workers ∈ {1, 4, 8, 16}` — slower, not faster.
+> Root cause: GIL contention in MCTS Python code that the bitboard
+> port did not eliminate. The shipped evaluator code itself is
+> correct (7/7 unit tests, deterministic vs the direct path) and
+> kept in-tree as a robustness path (it's the only parallel mode
+> that runs on Python 3.12 + the cloud image we tested), but the
+> design hypothesis below was wrong on this hardware. See "Threaded
+> BatchedEvaluator: results vs. prediction" in
+> `GPU_SCALING_RESULTS.md` for the post-mortem and the three forward
+> options (more bitboard, `torch.multiprocessing` with shared model,
+> or fix Python 3.12 spawn).
+
+> **Status**: implemented (PR #12), measured (negative result above).
+> Companion to `GPU_SCALING_PLAN.md` (PR #11) and
+> `GPU_SCALING_RESULTS.md`. The
 > 2026-05-05 sweep showed every other lever (`num_workers`,
-> `mcts_batch_size`) is exhausted; this is the next piece of work that
-> can plausibly move games/hr.
+> `mcts_batch_size`) is exhausted; this was the next piece of work
+> that *plausibly* could have moved games/hr — and it didn't.
 
 ## Why we need it
 

--- a/GPU_SCALING_RESULTS.md
+++ b/GPU_SCALING_RESULTS.md
@@ -156,3 +156,91 @@ Cudo Compute, RunPod *Community* Cloud, and unverified Vast.ai hosts
 are common offenders. RunPod *Secure* Cloud, Lambda Cloud, and
 Vast.ai's verified-host listings are safer. The probe above is the
 fastest way to detect the trap before burning sweep time.
+
+---
+
+## Threaded `BatchedEvaluator`: results vs. prediction (2026-05-06)
+
+> **Verdict**: the threaded shared-evaluator path lands at correctness
+> and robustness, but **does not deliver the predicted speedup**. On
+> the codebase as it stands, GIL contention in MCTS Python code makes
+> threads a net loss vs the serial path. Documented here so the next
+> person doesn't re-derive it.
+
+### What we predicted
+
+`BATCHED_EVALUATOR_DESIGN.md` and `IMPLEMENTATION_PLAN.md` Phase 3
+predicted **3-5× games/hr** from coalescing inference across N MCTS
+threads. The mental model: workers do CPU-side MCTS work, drain
+thread does GPU work, GPU usage rises from 15% to 50-70%.
+
+### What we measured
+
+Configuration: `cloud_smoke.yaml` (48 sims/move early, 32 late, 10
+games/iter, 1 iteration), EPYC 7763 (128 cores) + RTX 4090,
+driver 560.35.03 + torch 2.10.0+cu130. `gpu_probe` showed
+bare-metal-class single-stream throughput (3242 positions/sec,
+19.7ms/batch-64).
+
+| config                       | games/hr | sm_avg | sm_p95 |
+|---|---|---|---|
+| `num_workers=0` (serial)     | **702**  | 7.9    | n/a    |
+| `num_workers=1`, evaluator   | 541      | 6.4    | n/a    |
+| `num_workers=4`, evaluator   | 470      | 5.5    | 11     |
+| `num_workers=8`, evaluator   | 533*     | 5.1    | 17     |
+| `num_workers=16`, evaluator  | 489      | 5.2    | 18     |
+
+*`num_workers=8` measured at `max_wait_ms=10` (vs 1.0 default) — the
+single tunable knob that helped, +18% over the same-w default.
+
+### What we conclude
+
+**Serial wins.** Adding worker threads doesn't just fail to help — it
+*hurts* (470/489 vs 702). The threading and queue overhead costs more
+than the GPU/CPU overlap gains. Per-worker throughput drops linearly
+(`117 → 56 → 30 g/hr/worker`), the textbook signature of a serial
+wall.
+
+**The wall is the GIL.** The bitboard port moved a lot of MCTS
+compute to C++, but enough remains in Python (selection loop,
+valid-move enumeration, encoding, tree updates) that worker threads
+can't run in parallel — they serialize on the GIL.
+
+**The process pool isn't a clean baseline either.** On Python 3.12 +
+this cloud image, the spawn-context process pool dies during
+`_fixup_main_from_path` worker init before any games are generated.
+We didn't get a working `num_workers > 0` baseline with processes
+on this box. The 2026-05-05 sweep on the previous box (different
+CPU, Python 3.10) showed `num_workers=4` at 1250 g/hr with the
+process pool — that's the right number for "how fast can processes
+go on a different box", not directly comparable to today's
+threaded numbers.
+
+### What this changes
+
+- `cloud_run_v1.yaml` is now `num_workers: 0` and
+  `use_shared_evaluator: false`, sized at 25 iterations × 200 games
+  for ~5000 games / ~7h / ~$3.50 at the measured 702 g/hr.
+- `BATCHED_EVALUATOR_DESIGN.md` got a postscript flagging the
+  threaded shape as throughput-neutral on this codebase.
+- The shipped evaluator is **kept** in the codebase — it's correct
+  (7/7 unit tests, deterministic vs the direct path) and it's the
+  *only* parallel path that runs on Python 3.12 + this image. Future
+  bitboard work or a `torch.multiprocessing` rewrite may make it
+  worthwhile to re-measure.
+
+### What we'd try next, if speedup matters more
+
+1. **More bitboard.** Profile MCTS with the threaded path on; whatever
+   Python code shows up in `py-spy top` is what's holding the GIL.
+   Move it to C++ and re-measure threaded throughput.
+2. **`torch.multiprocessing` with shared model tensors.** Each worker
+   is a process (own GIL) but reads from a shared GPU tensor for the
+   network's parameters. Different shape than the threaded
+   evaluator.
+3. **Fix the Python 3.12 spawn issue.** Pin the launching script
+   structure so `_fixup_main_from_path` works in workers, recovering
+   the process-pool-with-cuda-init path that worked on the previous
+   box.
+
+None of these are in this PR. They're follow-ups, in the order above.

--- a/configs/cloud_run_v1.yaml
+++ b/configs/cloud_run_v1.yaml
@@ -1,16 +1,22 @@
 # cloud_run_v1.yaml — first sustained training run on a 4090 cloud box.
 #
-# Sized for an overnight ~8h run at ~$0.50/hr ($4-5 budget).
-# Throughput baseline: 1250 games/hr at num_workers=4 on the 2026-05-05
-# sweep. With BatchedEvaluator (target 3-5x), revisit the iteration
-# budget upward.
+# Throughput baseline: 702 games/hr at num_workers=0 (serial). Measured
+# 2026-05-06 on EPYC 7763 + 4090 cloud box. The 2026-05-06 sweep with
+# the shared BatchedEvaluator measured 470-541 games/hr across worker
+# counts 1, 4, 8, 16 — slower than serial. GIL contention in MCTS
+# Python code makes threading a net loss on this codebase. See
+# GPU_SCALING_RESULTS.md "Threaded evaluator: results vs prediction".
+#
+# Sizing: 25 iter × 200 games/iter = 5000 games. At 702 g/hr that's
+# ~7.1h of self-play, plus train+eval overhead → ~8h total.
+# At ~$0.50/hr that's $4 for the run.
 #
 # Differences vs cloud_smoke.yaml (which is a 1-iter perf-check):
-#   - 50 iterations instead of 2 — meaningful training horizon
+#   - 25 iterations instead of 2 — meaningful training horizon
 #   - 200 games/iter instead of 10 — enough for a stable buffer
 #   - Tournament games_per_match=20 instead of 6 — tighter ELO CIs
 #   - Buffer 100k instead of 50k — accommodates longer horizon
-#   - export_every=10 — periodic CoreML snapshots, not just at end
+#   - export_every=5 — periodic CoreML snapshots, not just at end
 #   - Anchor enabled — same defaults as smoke
 #
 # Knobs intentionally NOT changed from smoke:
@@ -18,13 +24,16 @@
 #   - heuristic schedule — proven decent in B1/B2
 #   - LR schedule + EMA — survived warmstart Phase D
 #
-# To turn on the BatchedEvaluator after Phase 3 validation lands:
-#   set `use_shared_evaluator: true` in self_play below; bump num_workers
-#   to 8 or 12 (it scales differently when the evaluator coalesces).
+# Why num_workers=0 instead of the threaded evaluator:
+#   The 2026-05-06 sweep measured serial > threaded for every
+#   (num_workers, max_wait_ms) combination tested. Once a future
+#   architectural change moves more MCTS work out of Python (more
+#   bitboard) or replaces threads with torch.multiprocessing shared-
+#   tensor processes, revisit. Until then, serial is the honest peak.
 
 version: 1
 device: auto
-num_iterations: 50
+num_iterations: 25
 save_dir: runs_cloud_v1
 
 self_play:
@@ -51,8 +60,8 @@ self_play:
   final_temp: 0.1
   annealing_steps: 30
   temp_clamp_fraction: 0.6
-  num_workers: 4                        # measured peak on 4090 (process pool); flip to 8 after Phase 3b
-  use_shared_evaluator: false           # toggle on once BatchedEvaluator is validated on the 4090
+  num_workers: 0                        # serial — measured peak on this hardware (702 g/hr). See header.
+  use_shared_evaluator: false           # threaded path is slower on this codebase; do not flip without re-measuring.
   games_per_iteration: 200
 
 trainer:
@@ -105,7 +114,7 @@ arena:
   revert_self_play_on_gate_failure: true
 
 export:
-  export_every: 10                      # periodic CoreML, not just final
+  export_every: 5                       # periodic CoreML — every 5/25 iterations
   coreml_dir: models/coreml
 
 difficulty_presets:


### PR DESCRIPTION
## Summary

Closes the GPU scaling investigation honestly. The threaded `BatchedEvaluator`
that landed in PR #12 was measured against the serial path on a 4090 cloud box
on 2026-05-06 and **underperformed by ~25%**.

## The data

EPYC 7763 + RTX 4090, `cloud_smoke.yaml` config (48 sims/move, 10 games/iter):

```
num_workers=0  (serial)         -> 702 games/hr   <- winner
num_workers=1, evaluator        -> 541
num_workers=4, evaluator        -> 470
num_workers=8, evaluator        -> 533  (max_wait_ms=10)
num_workers=16, evaluator       -> 489
```

Per-worker throughput drops linearly (`117 -> 56 -> 30 g/hr/worker`) — classic
serial-wall signature. Root cause is GIL contention in MCTS Python code that
the bitboard port did not eliminate (selection loop, valid-move enumeration,
encoding, tree updates remain pure Python).

The process pool isn't a clean baseline either — Python 3.12 + the cloud image
hit a spawn-side `_fixup_main_from_path` bug that kills workers before any
games generate.

## What's in this PR

1. **`GPU_SCALING_RESULTS.md` — new "Threaded BatchedEvaluator: results vs
   prediction" section.** Full data table, GIL conclusion, three forward
   options (more bitboard, `torch.multiprocessing` + shared model, fix Py3.12
   spawn).
2. **`BATCHED_EVALUATOR_DESIGN.md` — postscript at the top.** Anyone reading
   the design now sees the negative result first. Design body preserved for
   historical reference.
3. **`configs/cloud_run_v1.yaml` — flipped to serial baseline.**
   `num_workers: 0`, `use_shared_evaluator: false`, scaled to 25 iter × 200
   games for ~7h/$3.50 at the measured 702 g/hr. Header rewritten to reflect
   the honest baseline.

## What's NOT in this PR (intentionally)

- Reverting the `BatchedEvaluator` code itself. It's correct (7/7 unit tests,
  deterministic vs direct path), and on Python 3.12 + this cloud image it's
  the only parallel path that runs at all. Robustness-positive even if
  throughput-neutral.
- Any of the three forward options. Each is its own piece of work.

## Test plan

- [x] `configs/cloud_run_v1.yaml` parses cleanly (`yaml.safe_load`)
- [x] `num_workers: 0`, `use_shared_evaluator: false`, `num_iterations: 25`,
       `games_per_iteration: 200` all readable from the parsed config
- [x] (Reviewer) Sanity-check the cost arithmetic: 5000 games / 702 g/hr = 7.1h
       self-play + ~30min train+eval overhead = ~8h at $0.50/hr ~ $4
- [x] (Reviewer) Decide whether to launch this overnight on the box you have,
       or pursue one of the three forward options first
